### PR TITLE
resolvido problema nas funções ajax ao paginar

### DIFF
--- a/app/assets/javascripts/books.js
+++ b/app/assets/javascripts/books.js
@@ -27,7 +27,7 @@ function show_table(){
   
 }
 function openModal(){
-  $('.open-modal').on("click", function() {
+  $("body").on("click", '.open-modal', function() {
     $('#exampleModal').modal('show')
     var url = $(this).attr('data-url');
     var bookName = $(this).attr('data-name');  
@@ -47,7 +47,7 @@ function reload_button(){
   });
 }
 function delete_book(){
-  $('.destroybook').on("click", function() {
+  $("body").on("click", '.destroybook', function() {
     var bookid = $(this).attr('data-url');
     Swal.fire({
       title: 'Tem certeza ?',

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,18 +1,19 @@
 <h1>Livros</h1>
+<body>
+  <div class="form">
+    <%= form_tag '#', method:'get', class: 'searchformclass'  do %>
+      <%= label_tag("q[name_cont]", "Nome do Livro:")%>
+      <%= text_field_tag("q[name_cont]")%>
+      <%= link_to 'Pesquisar', "#", class:'searchbook btn btn-primary' %>
+      <%= link_to 'Limpar', "#" , class:' reloadbutton btn btn-primary' %>
+    <%end%>
+  </div>
 
-<div class="form">
-  <%= form_tag '#', method:'get', class: 'searchformclass'  do %>
-    <%= label_tag("q[name_cont]", "Nome do Livro:")%>
-    <%= text_field_tag("q[name_cont]")%>
-    <%= link_to 'Pesquisar', "#", class:'searchbook btn btn-primary' %>
-    <%= link_to 'Limpar', "#" , class:' reloadbutton btn btn-primary' %>
-  <%end%>
-</div>
+  <div class="createbutton">
+    <%=link_to "Cadastrar livro", new_book_path, class:'btn btn-primary'%><br>
+  </div>
 
-<div class="createbutton">
-  <%=link_to "Cadastrar livro", new_book_path, class:'btn btn-primary'%><br>
-</div>
+  <div id="ajaxtable"></div>
 
-<div id="ajaxtable"></div>
-
-<td><%= render 'layouts/modal'%></td>
+  <td><%= render 'layouts/modal'%></td>
+</body>

--- a/app/views/books/show_table.js.erb
+++ b/app/views/books/show_table.js.erb
@@ -1,2 +1,1 @@
 $("#ajaxtable").html("<%= escape_javascript render(:partial => 'layouts/table') %>")
-


### PR DESCRIPTION
O problema ocorria porque o enveto de click se perdia ao paginar.
Foi resolvido adicionando o evento ao um elemento pai que está fora da listagem que é atualizada dinamicamente via ajax

**O código era assim:**
function openModal(){
  **$('.open-modal').on("click", function() {**
    $('#exampleModal').modal('show')
    var url = $(this).attr('data-url');
    var bookName = $(this).attr('data-name');  
    $.ajax({url: url, success: function(result){
      $("#exampleModal .modal-body").html(result);
      $("#exampleModal .modal-title").html(bookName);
    }});
  });
}

**Ficou assim:**
function openModal(){
  **$("body").on("click", '.open-modal', function() {**
    $('#exampleModal').modal('show')
    var url = $(this).attr('data-url');
    var bookName = $(this).attr('data-name');  
    $.ajax({url: url, success: function(result){
      $("#exampleModal .modal-body").html(result);
      $("#exampleModal .modal-title").html(bookName);
    }});
  });
}